### PR TITLE
enhance integration with improved build options, CI, tests and cstool

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.zig text eol=lf
+*.zon text eol=lf

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        zig-version:
+          - 0.13.0
+          - master # Let's test master while it works so that breaking it is deliberate decision
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v1
+        with:
+          version: ${{ matrix.zig-version }}
+
+      - name: Check Formatting
+        run: zig fmt --ast-check --check .
+
+      - name: Build
+        run: zig build --summary all

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-zig-out/**
-zig-cache/**
-.zig-cache/**
+zig-out
+zig-cache
+.zig-cache

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
+[![CI](https://github.com/allyourcodebase/capstone/actions/workflows/ci.yaml/badge.svg)](https://github.com/allyourcodebase/capstone/actions)
+
 # capstone
-This just enables to use [capstone](https://github.com/capstone-engine/capstone) as a Dependency for the Zig build system.
+
+This is [capstone](https://github.com/capstone-engine/capstone), packaged for [Zig](https://ziglang.org/).
+
+## Installation
+
+First, update your `build.zig.zon`:
+
+```
+# Initialize a `zig build` project if you haven't already
+zig init
+zig fetch --save git+https://github.com/allyourcodebase/capstone.git#5.0.1
+```
+
+You can then import `capstone` in your `build.zig` with:
+
+```zig
+const capstone_dependency = b.dependency("capstone", .{
+    .target = target,
+    .optimize = optimize,
+});
+your_exe.linkLibrary(capstone_dependency.artifact("capstone"));
+```

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
     .name = "capstone",
     .version = "5.0.1",
+    .minimum_zig_version = "0.13.0",
 
     .dependencies = .{
         .capstone = .{


### PR DESCRIPTION
I recently worked on adding capstone to allyourcodebase without realizing that it already existed. My port has done various things differently so here I am.

Changes to `build.zig`:
- add a single `supported-architectures` option instead of options for each arch
- add general build options like `-Dshared` `-Dstrip` and `-Dpie`
- port capstone's build options like `CAPSTONE_USE_DEFAULT_ALLOC`, `CAPSTONE_BUILD_DIET` `CAPSTONE_X86_REDUCE`
- install platform.h into the capstone include directory to match upstream
- don't add the source files for disabled architectures
- build and install cstool
- port tests/

Previously, capstone would be build as a shared library. Usually static linking should be preferred so I added a `shared` build option and made it default to false. 

I've also realized that this repository has not tagged a release. While this usually isn't a big deal, when adding an installation guide, it is nice to refer to a tag instead of a "random" commit hash. See 8dd0873912e4e3e5ee99d7cd5e0f6ce69245497d
I believe it's best to take the same approach as https://github.com/allyourcodebase/zlib.