### PR TITLE
don't install header files into subdirectory to match upstream

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,3 +36,6 @@ jobs:
 
       - name: Build
         run: zig build --summary all
+
+      - name: Test
+        run: zig build run-all-tests --summary all

--- a/build.zig
+++ b/build.zig
@@ -48,8 +48,9 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(capstone);
     capstone.addIncludePath(upstream.path("include"));
-    capstone.installHeadersDirectory(upstream.path("include/capstone"), "capstone", .{});
-    capstone.installHeader(upstream.path("include/platform.h"), "capstone/platform.h");
+    // The header files should be installed in a 'capstone' subdirectory in capstone v6.
+    capstone.installHeadersDirectory(upstream.path("include/capstone"), "", .{});
+    capstone.installHeader(upstream.path("include/platform.h"), "platform.h");
     capstone.addCSourceFiles(.{ .root = upstream.path(""), .files = common_sources });
 
     if (build_diet) capstone.root_module.addCMacro("CAPSTONE_DIET", "");
@@ -81,6 +82,7 @@ pub fn build(b: *std.Build) void {
             .strip = strip,
             .link_libc = true,
         });
+        cstool.addIncludePath(upstream.path("include")); // remove this in capstone v6
         cstool.linkLibrary(capstone);
         cstool.addCSourceFiles(.{ .root = upstream.path("cstool"), .files = cstool_sources });
         cstool.addCSourceFile(.{ .file = upstream.path("cstool/getopt.c") });
@@ -116,6 +118,7 @@ pub fn build(b: *std.Build) void {
                 .strip = strip,
                 .link_libc = true,
             });
+            exe.addIncludePath(upstream.path("include")); // remove this in capstone v6
             exe.linkLibrary(capstone);
             exe.addCSourceFile(.{ .file = upstream.path("tests").path(b, file) });
 


### PR DESCRIPTION
The include path for capstone v5 installed with pkg-config already includes the `capstone` sub directory so that header files can only be included with `#include <capstone.h>`. This appears to be unintentional and has been changed in capstone v6 to support `#include <capstone/capstone.h>`.

Since Zig is primarily used with pkg-config to lookup system libraries. We should match the pkg-config behavior until this port is updated to v6.

The difference in include paths can be found here:
- [5.0.6/capstone.pc.in](https://github.com/capstone-engine/capstone/blob/5.0.6/capstone.pc.in#L12)
- [6.0.0-Alpha1/capstone.pc.in](https://github.com/capstone-engine/capstone/blob/6.0.0-Alpha1/capstone.pc.in#L13)
 